### PR TITLE
fix: возвращать главное меню после callback оплаты

### DIFF
--- a/internal/bot/payment.go
+++ b/internal/bot/payment.go
@@ -11,7 +11,6 @@ import (
 	"github.com/fus1ond/vpn_bot/internal/callback"
 	"github.com/fus1ond/vpn_bot/internal/database"
 	"github.com/fus1ond/vpn_bot/internal/platega"
-	tele "gopkg.in/telebot.v3"
 )
 
 // paymentMu — мьютексы по telegram_id для защиты от race condition при обработке callback.
@@ -157,20 +156,11 @@ func (b *Bot) paymentActivatedMessage(telegramID int64) string {
 }
 
 func (h *paymentCallbackHandler) finalizeActivatedPayment(payment *database.Payment, notifyUser bool) {
-	// Сбрасываем состояние оплаты, чтобы убрать клавиатуру "Проверить оплату"
+	// Сбрасываем состояние ожидания оплаты
 	h.bot.userStates.Delete(payment.TelegramID)
 
 	if notifyUser {
-		msg := h.bot.paymentActivatedMessage(payment.TelegramID)
-		kb := h.bot.userKeyboard(payment.TelegramID)
-		_, err := h.bot.bot.Send(&tele.User{ID: payment.TelegramID}, msg, &tele.SendOptions{
-			ParseMode:   tele.ModeHTML,
-			ReplyMarkup: kb,
-		})
-		if err != nil {
-			slog.Warn("Не удалось отправить уведомление об активации с клавиатурой",
-				"telegram_id", payment.TelegramID, "error", err)
-		}
+		_ = h.bot.sendSchedulerMessageWithKeyboard(payment.TelegramID, h.bot.paymentActivatedMessage(payment.TelegramID), h.bot.userKeyboard(payment.TelegramID))
 	}
 
 	// Очищаем уведомления (пользователь мог быть в grace period)
@@ -409,7 +399,8 @@ func (h *paymentCallbackHandler) handleCanceled(payment *database.Payment) error
 	if err := h.bot.db.UpdatePaymentStatus(payment.ID, "canceled"); err != nil {
 		return fmt.Errorf("update status to canceled: %w", err)
 	}
-	_ = h.bot.sendSchedulerMessage(payment.TelegramID, "❌ Платёж отменён. Вы можете попробовать снова.")
+	h.bot.userStates.Delete(payment.TelegramID)
+	_ = h.bot.sendSchedulerMessageWithKeyboard(payment.TelegramID, "❌ Платёж отменён. Вы можете попробовать снова.", h.bot.userKeyboard(payment.TelegramID))
 	return nil
 }
 

--- a/internal/bot/payment.go
+++ b/internal/bot/payment.go
@@ -156,8 +156,8 @@ func (b *Bot) paymentActivatedMessage(telegramID int64) string {
 }
 
 func (h *paymentCallbackHandler) finalizeActivatedPayment(payment *database.Payment, notifyUser bool) {
-	// Сбрасываем состояние ожидания оплаты
-	h.bot.userStates.Delete(payment.TelegramID)
+	// Сбрасываем состояние только если пользователь всё ещё в платёжном flow
+	h.bot.userStates.DeleteIfOneOf(payment.TelegramID, StateWaitPaymentMethod, StateWaitPaymentResult)
 
 	if notifyUser {
 		_ = h.bot.sendSchedulerMessageWithKeyboard(payment.TelegramID, h.bot.paymentActivatedMessage(payment.TelegramID), h.bot.userKeyboard(payment.TelegramID))
@@ -399,7 +399,7 @@ func (h *paymentCallbackHandler) handleCanceled(payment *database.Payment) error
 	if err := h.bot.db.UpdatePaymentStatus(payment.ID, "canceled"); err != nil {
 		return fmt.Errorf("update status to canceled: %w", err)
 	}
-	h.bot.userStates.Delete(payment.TelegramID)
+	h.bot.userStates.DeleteIfOneOf(payment.TelegramID, StateWaitPaymentMethod, StateWaitPaymentResult)
 	_ = h.bot.sendSchedulerMessageWithKeyboard(payment.TelegramID, "❌ Платёж отменён. Вы можете попробовать снова.", h.bot.userKeyboard(payment.TelegramID))
 	return nil
 }

--- a/internal/bot/payment.go
+++ b/internal/bot/payment.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fus1ond/vpn_bot/internal/callback"
 	"github.com/fus1ond/vpn_bot/internal/database"
 	"github.com/fus1ond/vpn_bot/internal/platega"
+	tele "gopkg.in/telebot.v3"
 )
 
 // paymentMu — мьютексы по telegram_id для защиты от race condition при обработке callback.
@@ -156,8 +157,20 @@ func (b *Bot) paymentActivatedMessage(telegramID int64) string {
 }
 
 func (h *paymentCallbackHandler) finalizeActivatedPayment(payment *database.Payment, notifyUser bool) {
+	// Сбрасываем состояние оплаты, чтобы убрать клавиатуру "Проверить оплату"
+	h.bot.userStates.Delete(payment.TelegramID)
+
 	if notifyUser {
-		_ = h.bot.sendSchedulerMessage(payment.TelegramID, h.bot.paymentActivatedMessage(payment.TelegramID))
+		msg := h.bot.paymentActivatedMessage(payment.TelegramID)
+		kb := h.bot.userKeyboard(payment.TelegramID)
+		_, err := h.bot.bot.Send(&tele.User{ID: payment.TelegramID}, msg, &tele.SendOptions{
+			ParseMode:   tele.ModeHTML,
+			ReplyMarkup: kb,
+		})
+		if err != nil {
+			slog.Warn("Не удалось отправить уведомление об активации с клавиатурой",
+				"telegram_id", payment.TelegramID, "error", err)
+		}
 	}
 
 	// Очищаем уведомления (пользователь мог быть в grace period)

--- a/internal/bot/scheduler.go
+++ b/internal/bot/scheduler.go
@@ -340,6 +340,18 @@ func (b *Bot) sendSchedulerMessage(telegramID int64, message string) error {
 	return err
 }
 
+// sendSchedulerMessageWithKeyboard отправляет сообщение с клавиатурой (для замены текущих кнопок)
+func (b *Bot) sendSchedulerMessageWithKeyboard(telegramID int64, message string, markup *tele.ReplyMarkup) error {
+	if b.bot == nil {
+		return fmt.Errorf("telegram bot is not initialized")
+	}
+	_, err := b.bot.Send(&tele.User{ID: telegramID}, message, &tele.SendOptions{
+		ParseMode:   tele.ModeHTML,
+		ReplyMarkup: markup,
+	})
+	return err
+}
+
 // isSchedulerForbiddenError проверяет, заблокировал ли пользователь бот или деактивирован.
 func isSchedulerForbiddenError(err error) bool {
 	return errors.Is(err, tele.ErrBlockedByUser) ||

--- a/internal/bot/state_map.go
+++ b/internal/bot/state_map.go
@@ -35,3 +35,16 @@ func (sm *stateMap) Delete(telegramID int64) {
 	defer sm.mu.Unlock()
 	delete(sm.m, telegramID)
 }
+
+// DeleteIfOneOf удаляет состояние только если оно совпадает с одним из переданных
+func (sm *stateMap) DeleteIfOneOf(telegramID int64, states ...string) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	cur := sm.m[telegramID]
+	for _, s := range states {
+		if cur == s {
+			delete(sm.m, telegramID)
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- После callback от Platega (успешная оплата/отмена) кнопки «Проверить оплату» и «Отмена» оставались — бот отправлял сообщение без клавиатуры
- Теперь callback-уведомления отправляются с `userKeyboard` (главное меню), состояние ожидания оплаты сбрасывается
- Добавлен `sendSchedulerMessageWithKeyboard` для отправки сообщений с клавиатурой из фоновых обработчиков

## Test plan
- [x] `make tests` — все тесты проходят
- [x] `make fmt` — форматирование в порядке

🤖 Generated with [Claude Code](https://claude.com/claude-code)