### PR TITLE
fix: inline-кнопки не работали — подписка на callback_query

### DIFF
--- a/internal/bot/bot_settings_test.go
+++ b/internal/bot/bot_settings_test.go
@@ -1,0 +1,21 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	tele "gopkg.in/telebot.v3"
+)
+
+// Регрессия: бот обязан подписываться на callback_query, иначе Telegram не
+// присылает нажатия inline-кнопок и управление устройствами не работает.
+func TestBuildBotSettingsSubscribesToCallbackQuery(t *testing.T) {
+	settings := buildBotSettings("test-token")
+
+	poller, ok := settings.Poller.(*tele.LongPoller)
+	require.True(t, ok, "poller должен быть *tele.LongPoller")
+	require.Contains(t, poller.AllowedUpdates, "callback_query",
+		"LongPoller должен явно подписываться на callback_query")
+	require.Contains(t, poller.AllowedUpdates, "message",
+		"LongPoller должен по-прежнему получать обычные сообщения")
+}

--- a/internal/bot/handlers.go
+++ b/internal/bot/handlers.go
@@ -50,12 +50,24 @@ type Bot struct {
 	adminPriceData       map[int64]adminChangePriceSession // pending-данные изменения цены для админа
 }
 
+// buildBotSettings собирает настройки telebot.
+//
+// LongPoller обязательно подписываем на полный список типов апдейтов
+// (tele.AllowedUpdates включает callback_query). Без явного AllowedUpdates
+// Telegram использует дефолтный набор getUpdates, который НЕ содержит
+// callback_query, — тогда нажатия inline-кнопок боту не приходят вовсе.
+func buildBotSettings(token string) tele.Settings {
+	return tele.Settings{
+		Token: token,
+		Poller: &tele.LongPoller{
+			AllowedUpdates: tele.AllowedUpdates,
+		},
+	}
+}
+
 // New создаёт нового Telegram бота
 func New(cfg *config.Config, db *database.DB, remnawaveClient *remnawave.Client) (*Bot, error) {
-	pref := tele.Settings{
-		Token:  cfg.BotToken,
-		Poller: &tele.LongPoller{},
-	}
+	pref := buildBotSettings(cfg.BotToken)
 
 	b, err := tele.NewBot(pref)
 	if err != nil {


### PR DESCRIPTION
## Проблема

После мержа #60 в проде inline-кнопки управления устройствами **совсем не реагировали** на нажатия: список устройств приходил, но клик по устройству / «Сбросить все» / «Закрыть» не давал ничего.

## Root cause

Бот создавал поллер как `&tele.LongPoller{}` — без `AllowedUpdates`. В этом случае telebot шлёт в `getUpdates` `allowed_updates=null`, а Telegram при пустом значении применяет **дефолтный набор апдейтов, который не содержит `callback_query`**. Поэтому нажатия inline-кнопок боту вообще не приходили (в логах прода — ни одной строки `Incoming callback`, хотя reply-кнопки `message` логировались штатно).

Бот исторически работал только на reply-клавиатуре, поэтому проблема всплыла лишь с появлением первых inline-кнопок.

Диагностика — по логам прода + разбор telebot v3.3.8 (`poller.go`, `api.go:getUpdates`, `update.go:ProcessUpdate`).

## Фикс

Подписываем `LongPoller` на полный список типов апдейтов (включает `callback_query`):

```go
Poller: &tele.LongPoller{AllowedUpdates: tele.AllowedUpdates}
```

Построение настроек вынесено в чистую функцию `buildBotSettings` ради тестируемости.

## Тест

`TestBuildBotSettingsSubscribesToCallbackQuery` — регрессия: проверяет, что поллер подписан на `callback_query` и `message`. Прогон red-green подтверждён (без фикса тест падает «does not contain callback_query»).

- `go vet ./...` — exit 0
- `go test ./... -count=1` — все пакеты `ok`

После мержа CI пересоберёт образ, на проде останется `docker compose pull vpn-bot && docker compose up -d vpn-bot`.