### PR TITLE
fix: дедупликация подписчиков модератора по used_by

### DIFF
--- a/internal/database/invites.go
+++ b/internal/database/invites.go
@@ -594,13 +594,28 @@ func (db *DB) GetInviteByUsedBy(usedBy int64) (*Invite, error) {
 // GetSubscribersByModerator возвращает подписчиков, приглашённых модератором.
 // Пользователи без записи в users также возвращаются (LEFT JOIN).
 func (db *DB) GetSubscribersByModerator(moderatorID int64) ([]Subscriber, error) {
+	// Дедуплицируем по used_by: один пользователь может активировать несколько
+	// инвайтов модератора (повторная регистрация, продление новым инвайтом),
+	// но в списке подписчиков должен учитываться один раз — по последнему инвайту.
+	// ROW_NUMBER ранжирует инвайты пользователя и оставляет только последний (rn=1);
+	// тай-брейк по rowid снимает недетерминизм при равных used_at/created_at.
 	rows, err := db.conn.Query(
-		`SELECT i.used_by, u.username, u.first_name, u.remnawave_uuid,
-		        COALESCE(u.subscription_price, i.subscription_price)
-		 FROM invites i
-		 LEFT JOIN users u ON i.used_by = u.telegram_id
-		 WHERE i.created_by = ? AND i.used_by IS NOT NULL
-		 ORDER BY i.used_at DESC, i.created_at DESC`,
+		`WITH ranked AS (
+		     SELECT i.used_by, i.used_at, i.created_at,
+		            i.subscription_price AS inv_price,
+		            ROW_NUMBER() OVER (
+		                PARTITION BY i.used_by
+		                ORDER BY i.used_at DESC, i.created_at DESC, i.rowid DESC
+		            ) AS rn
+		     FROM invites i
+		     WHERE i.created_by = ? AND i.used_by IS NOT NULL
+		 )
+		 SELECT r.used_by, u.username, u.first_name, u.remnawave_uuid,
+		        COALESCE(u.subscription_price, r.inv_price)
+		 FROM ranked r
+		 LEFT JOIN users u ON r.used_by = u.telegram_id
+		 WHERE r.rn = 1
+		 ORDER BY r.used_at DESC, r.created_at DESC`,
 		moderatorID,
 	)
 	if err != nil {

--- a/internal/database/invites_ext_test.go
+++ b/internal/database/invites_ext_test.go
@@ -123,6 +123,58 @@ func TestGetSubscribersByModerator(t *testing.T) {
 	assert.Nil(t, deleted.RemnawaveUUID)
 }
 
+// TestGetSubscribersByModerator_Dedup проверяет, что пользователь, активировавший
+// несколько инвайтов одного модератора, считается один раз (без двойного счёта).
+func TestGetSubscribersByModerator_Dedup(t *testing.T) {
+	db := setupTestDBInvites(t)
+
+	// Пользователь без записи о цене в users — цена должна браться из инвайта (COALESCE)
+	_, err := db.CreateUser(300, "doubleuser", "Double", "uuid-300", nil, nil)
+	require.NoError(t, err)
+
+	// Старый инвайт (цена 400, активирован раньше)
+	inv1, err := db.CreateInviteWithExpiry(100, intPtr(30))
+	require.NoError(t, err)
+	require.NoError(t, db.ClaimInvite(inv1.Code, 300))
+	_, err = db.Conn().Exec(`UPDATE invites SET subscription_price = 400, used_at = '2026-04-01 10:00:00' WHERE code = ?`, inv1.Code)
+	require.NoError(t, err)
+
+	// Новый инвайт (цена 500, активирован позже) — именно его данные должны вернуться
+	inv2, err := db.CreateInviteWithExpiry(100, intPtr(30))
+	require.NoError(t, err)
+	require.NoError(t, db.ClaimInvite(inv2.Code, 300))
+	_, err = db.Conn().Exec(`UPDATE invites SET subscription_price = 500, used_at = '2026-05-01 10:00:00' WHERE code = ?`, inv2.Code)
+	require.NoError(t, err)
+
+	// Контрольный пользователь с одним инвайтом — должен остаться отдельной записью
+	_, err = db.CreateUser(301, "single", "Single", "uuid-301", nil, nil)
+	require.NoError(t, err)
+	inv3, err := db.CreateInviteWithExpiry(100, intPtr(30))
+	require.NoError(t, err)
+	require.NoError(t, db.ClaimInvite(inv3.Code, 301))
+
+	subs, err := db.GetSubscribersByModerator(100)
+	require.NoError(t, err)
+
+	// Двойной пользователь учитывается один раз, контрольный — отдельно: всего 2
+	require.Len(t, subs, 2, "пользователь с несколькими инвайтами модератора должен считаться один раз")
+
+	seen := map[int64]Subscriber{}
+	for _, sub := range subs {
+		_, dup := seen[sub.TelegramID]
+		require.False(t, dup, "telegram_id %d не должен дублироваться", sub.TelegramID)
+		seen[sub.TelegramID] = sub
+	}
+
+	require.Contains(t, seen, int64(300))
+	require.NotNil(t, seen[300].Username)
+	assert.Equal(t, "doubleuser", *seen[300].Username)
+	// Данные должны быть взяты из ПОСЛЕДНЕГО инвайта (цена 500, не 400)
+	require.NotNil(t, seen[300].SubscriptionPrice)
+	assert.Equal(t, 500, *seen[300].SubscriptionPrice, "должна вернуться цена последнего инвайта")
+	require.Contains(t, seen, int64(301))
+}
+
 func intPtr(v int) *int {
 	return &v
 }


### PR DESCRIPTION
## Проблема

`GetSubscribersByModerator` возвращал подписчиков модератора по строкам использованных инвайтов **без дедупликации по пользователю**. Если один человек активировал несколько инвайтов одного модератора (повторная регистрация / продление новым инвайтом), он попадал в список несколько раз.

Эффект: в админ-отчёте по модераторам завышались счётчики «💳 Платящих / ⏳ Триал / ⚠️ Grace». Реальный кейс на проде — у одного модератора показывало **7 платящих вместо 5** (двое рефералов активировали по 2 инвайта и считались дважды).

На расчёт долей (earnings) баг **не влияет** — там деньги считаются по платежам, а ставка — через `COUNT(DISTINCT)`. Завышался только отображаемый счётчик.

## Решение

Запрос переписан на оконную функцию `ROW_NUMBER()` с `PARTITION BY used_by`: для каждого пользователя остаётся только **последний** инвайт (`rn = 1`), сортировка `used_at DESC, created_at DESC, rowid DESC`.

Почему именно так (а не `GROUP BY` + `HAVING`):
- `GROUP BY used_by` с bare-колонками в SQLite недетерминирован — нельзя надёжно выбрать «последнюю» строку группы. Вариант через `HAVING rowid = (подзапрос)` при разных `used_at` **терял пользователя целиком** (возвращал 0 строк вместо 1) — это хуже исходного бага. Поймано на code-review и подтверждено прямым SQL-тестом.
- `ROW_NUMBER()` детерминирован; тай-брейк по `rowid` снимает неоднозначность при равных `used_at` (частый случай из-за односекундной гранулярности `CURRENT_TIMESTAMP`).
- `LEFT JOIN users` выполняется **после** ранжирования, поэтому поведение для удалённого из `users` подписчика сохраняется (поля → `nil`).

`mattn/go-sqlite3 v1.14.22` несёт SQLite ≥ 3.25 — оконные функции доступны.

## Тесты

- Добавлен `TestGetSubscribersByModerator_Dedup`: один пользователь с двумя инвайтами (разные `used_at`, разные цены) + контрольный одиночный → ожидается 2 записи без дублей, цена берётся из последнего инвайта (500, не 400).
- Verify RED: тест падает на старом запросе (3 записи вместо 2), проходит на новом.
- Существующий `TestGetSubscribersByModerator` (удалённый из users подписчик) не сломан.
- `make fmt` и `make tests` — зелёные.